### PR TITLE
JS Fixes for 5.52

### DIFF
--- a/ang/partials/ruleEditCtrl.html
+++ b/ang/partials/ruleEditCtrl.html
@@ -48,14 +48,14 @@
       <td class="label">{{ts('Profile(s)')}}</td>
       <td>
         <select
+          class="huge"
           multiple
-          ui-jq="select2"
-          ui-options="{dropdownAutoWidth : true}"
+          crm-ui-select="{dropdownAutoWidth : true}"
           required
           id="uf_group_id"
           ng-model="rule.uf_group_id"
-          ng-options="profile.id as profile.title for profile in profiles| orderBy:'title'"
           >
+          <option value="{{ profile.id }}" ng-repeat="profile in profiles| orderBy:'title'">{{ profile.title }}</option>
         </select><br />
         <span class="description">{{ts('This rule will only apply on the selected profile(s).')}}</span></td>
     </tr>

--- a/ang/partials/rules.html
+++ b/ang/partials/rules.html
@@ -1,9 +1,11 @@
 <div class="crm-container">
-<button crm-icon="fa-plus-circle" ng-click="openEditForm()">Add Rule</button>
+  <div class="crm-clearfix">
+    <button crm-icon="fa-plus-circle" ng-click="openEditForm()">Add Rule</button>
+  </div>
   <div crm-ui-debug="profiles"></div>
   <h1 crm-page-title>{{ts('Map Pin Rules')}}</h1>
 
-  <div crm-ui-tab-set tab-set-options="{{myTabSetOptions}}">
+  <div crm-ui-tab-set tab-set-options="myTabSetOptions">
     <div id="mappinsRule-tab-perProfile" crm-ui-tab crm-title="ts('Per Profile')">
       <label for="profile">Profile</label>
       <select id="profile" ng-model="selectedProfile" ng-options="profile as profile.title for profile in profiles | orderBy:'title'" ng-change="setSelectedProfile(selectedProfile);"></select>
@@ -29,7 +31,7 @@
             </tr>
           </thead>
           <tbody ui-sortable="{'stop': saveWeights, 'axis': 'y'}" ng-model="rules.selectedProfile" id="selectedProfileRules">
-            <tr             
+            <tr
               ng-repeat="(key, value) in rules.selectedProfile"
               ng-class="{'disabled': value.rule.is_active == 0}"
               ng-include="'~/mappins/blockRuleRow.html'"
@@ -38,7 +40,7 @@
               ng-class-odd="'odd-row'"
             ></tr>
           </tbody>
-        </table>        
+        </table>
       </div>
       <div ng-if="(selectedProfile.id == 0 || ! _.isEmpty(rules.unassigned))">
         <h2>All profiles fall back to these rules:</h2>
@@ -56,7 +58,7 @@
             </tr>
           </thead>
           <tbody ui-sortable="{stop: saveWeights, 'axis': 'y'}" ng-model="rules.unassigned" id="unassignedRules">
-            <tr             
+            <tr
               ng-repeat="(key, value) in rules.unassigned"
               ng-class="{'disabled': value.rule.is_active == 0}"
               ng-include="'~/mappins/blockRuleRow.html'"
@@ -65,7 +67,7 @@
               ng-class-odd="'odd-row'"
             ></tr>
           </tbody>
-        </table>        
+        </table>
       </div>
     </div>
     <div id="mappinsRule-tab-all" crm-ui-tab crm-title="ts('All')"">
@@ -82,7 +84,7 @@
             </tr>
           </thead>
           <tbody>
-            <tr             
+            <tr
               ng-repeat="value in allRules"
               ng-class="(value.is_active == 0 ? 'disabled' : '')"
               ng-include="'~/mappins/blockRuleRow.html'"
@@ -91,7 +93,7 @@
               ng-class-odd="'odd-row'"
             ></tr>
           </tbody>
-        </table>              
+        </table>
     </div>
   </div>
 </div>

--- a/info.xml
+++ b/info.xml
@@ -18,7 +18,7 @@
   <version>0.2</version>
   <develStage>alpha</develStage>
   <compatibility>
-    <ver>4.7</ver>
+    <ver>5.52</ver>
   </compatibility>
   <comments>After installation, configure rules at Administrator &gt; Customize Data and Screens &gt; Map Pins.</comments>
   <civix>


### PR DESCRIPTION
There are a couple breaking changes in 5.52 which I'm pushing updates for:

- `CrmUiTabs` no longer takes its `tab-set-options` object as a string. AFAIK this is the only module in the Civi universe that was using that setting (you wrote it) and so I think it's best to bite the bullet and fix it rather than try to support the wrong data type going forward.
- The `ui-jq` library has been removed. I thought it would be a simple drop-in replacement to use `crm-ui-select` but that has an unfortunate bug causing it to not work with `ng-options`. Solution was to use `ng-repeat` on an `<option>` element.
- In my testing the button was not visible (it was floating behind the tabset) so I wrapped it in a div.