### PR TITLE
Remove calls to deprecated CRM_Utils_Array::value

### DIFF
--- a/CRM/Mappins/BAO/MappinsRule.php
+++ b/CRM/Mappins/BAO/MappinsRule.php
@@ -17,7 +17,7 @@ class CRM_Mappins_BAO_MappinsRule extends CRM_Mappins_DAO_MappinsRule {
 
     $hook = empty($params['id']) ? 'create' : 'edit';
 
-    CRM_Utils_Hook::pre($hook, $entityName, CRM_Utils_Array::value('id', $params), $params);
+    CRM_Utils_Hook::pre($hook, $entityName, $params['id'] ?? NULL, $params);
     $instance = new $className();
     $instance->copyValues($params);
     $instance->save();

--- a/CRM/Mappins/BAO/MappinsRuleProfile.php
+++ b/CRM/Mappins/BAO/MappinsRuleProfile.php
@@ -12,7 +12,7 @@ class CRM_Mappins_BAO_MappinsRuleProfile extends CRM_Mappins_DAO_MappinsRuleProf
   // $entityName = 'MappinsRuleProfile';
   // $hook = empty($params['id']) ? 'create' : 'edit';
 
-  // CRM_Utils_Hook::pre($hook, $entityName, CRM_Utils_Array::value('id', $params), $params);
+  // CRM_Utils_Hook::pre($hook, $entityName, $params['id'] ?? NULL, $params);
   // $instance = new $className();
   // $instance->copyValues($params);
   // $instance->save();

--- a/mappins.php
+++ b/mappins.php
@@ -22,7 +22,7 @@ function mappins_civicrm_buildForm($formName, &$form) {
   if ($formName == 'CRM_Contact_Form_Task_Map') {
     // Determine profile gid.
     parse_str(html_entity_decode($form->controller->_entryURL), $entryURL);
-    $gid = CRM_Utils_Array::value('gid', $entryURL);
+    $gid = $entryURL['gid'] ?? NULL;
 
     // Instantiate a map object and replace the pins, being sure to convey the
     // Profile gid so that only rules for this profile are applied.


### PR DESCRIPTION
Replaces deprecated function with equivalent null-coalescing operator. Behavior should be the same before/after.