### PR TITLE
Replace reference to deprecated exception class

### DIFF
--- a/api/v3/MappinsRule.php
+++ b/api/v3/MappinsRule.php
@@ -17,7 +17,6 @@ function _civicrm_api3_mappins_rule_create_spec(&$spec) {
  *
  * @param array $params
  * @return array API result descriptor
- * @throws CRM_Core_Exception
  */
 function civicrm_api3_mappins_rule_create($params) {
   $ret = _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params);
@@ -106,7 +105,6 @@ function _civicrm_api3_mappins_rule_create_mappins_rule_profile($params, $rule) 
  *
  * @param array $params
  * @return array API result descriptor
- * @throws CRM_Core_Exception
  */
 function civicrm_api3_mappins_rule_delete($params) {
   return _civicrm_api3_basic_delete(_civicrm_api3_get_BAO(__FUNCTION__), $params);
@@ -117,7 +115,6 @@ function civicrm_api3_mappins_rule_delete($params) {
  *
  * @param array $params
  * @return array API result descriptor
- * @throws CRM_Core_Exception
  */
 function civicrm_api3_mappins_rule_get($params) {
   $options = _civicrm_api3_get_options_from_params($params);

--- a/api/v3/MappinsRule.php
+++ b/api/v3/MappinsRule.php
@@ -17,7 +17,7 @@ function _civicrm_api3_mappins_rule_create_spec(&$spec) {
  *
  * @param array $params
  * @return array API result descriptor
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_mappins_rule_create($params) {
   $ret = _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params);
@@ -106,7 +106,7 @@ function _civicrm_api3_mappins_rule_create_mappins_rule_profile($params, $rule) 
  *
  * @param array $params
  * @return array API result descriptor
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_mappins_rule_delete($params) {
   return _civicrm_api3_basic_delete(_civicrm_api3_get_BAO(__FUNCTION__), $params);
@@ -117,7 +117,7 @@ function civicrm_api3_mappins_rule_delete($params) {
  *
  * @param array $params
  * @return array API result descriptor
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_mappins_rule_get($params) {
   $options = _civicrm_api3_get_options_from_params($params);

--- a/api/v3/MappinsRuleProfile.php
+++ b/api/v3/MappinsRuleProfile.php
@@ -17,7 +17,6 @@ function _civicrm_api3_mappins_rule_profile_create_spec(&$spec) {
  *
  * @param array $params
  * @return array API result descriptor
- * @throws CRM_Core_Exception
  */
 function civicrm_api3_mappins_rule_profile_create($params) {
   return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params);
@@ -28,7 +27,6 @@ function civicrm_api3_mappins_rule_profile_create($params) {
  *
  * @param array $params
  * @return array API result descriptor
- * @throws CRM_Core_Exception
  */
 function civicrm_api3_mappins_rule_profile_delete($params) {
   return _civicrm_api3_basic_delete(_civicrm_api3_get_BAO(__FUNCTION__), $params);
@@ -39,7 +37,6 @@ function civicrm_api3_mappins_rule_profile_delete($params) {
  *
  * @param array $params
  * @return array API result descriptor
- * @throws CRM_Core_Exception
  */
 function civicrm_api3_mappins_rule_profile_get($params) {
   if (empty($params['return'])) {

--- a/api/v3/MappinsRuleProfile.php
+++ b/api/v3/MappinsRuleProfile.php
@@ -17,7 +17,7 @@ function _civicrm_api3_mappins_rule_profile_create_spec(&$spec) {
  *
  * @param array $params
  * @return array API result descriptor
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_mappins_rule_profile_create($params) {
   return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params);
@@ -28,7 +28,7 @@ function civicrm_api3_mappins_rule_profile_create($params) {
  *
  * @param array $params
  * @return array API result descriptor
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_mappins_rule_profile_delete($params) {
   return _civicrm_api3_basic_delete(_civicrm_api3_get_BAO(__FUNCTION__), $params);
@@ -39,7 +39,7 @@ function civicrm_api3_mappins_rule_profile_delete($params) {
  *
  * @param array $params
  * @return array API result descriptor
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_mappins_rule_profile_get($params) {
   if (empty($params['return'])) {


### PR DESCRIPTION
The api-specific exception classes have been deprecated and will soon be removed from core.
They are identical to CRM_Core_Exception.