### PR TITLE
Use public function to get template vars

### DIFF
--- a/CRM/Mappins/MappinsMap.php
+++ b/CRM/Mappins/MappinsMap.php
@@ -70,9 +70,11 @@ class CRM_Mappins_MappinsMap {
    * src of the pin images within the Smarty template variables.
    */
   public function replaceLocationPins() {
-    foreach ($this->tpl->_tpl_vars['locations'] as &$location) {
+    $locations = $this->tpl->getTemplateVars('locations');
+    foreach ($locations as &$location) {
       $this->setLocationImage($location);
     }
+    $this->tpl->assign('locations', $locations);
   }
 
   /**


### PR DESCRIPTION
Direct access to this internal smarty variable is not recommended. This switches to using the public getter function instead.